### PR TITLE
Fixed Allocation of Resources Without Limits or ttp vulnerable to a reset flood

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,22 +2,13 @@ module github.com/yahoo/k8s-athenz-identity
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/gogo/protobuf v1.1.1 // indirect
-	github.com/golang/protobuf v1.3.2 // indirect
-	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
-	github.com/mash/go-accesslog v1.1.0
 	github.com/pkg/errors v0.8.1
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/yahoo/athenz v1.8.40
-	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
-	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
-	k8s.io/api v0.15.7
-	k8s.io/apimachinery v0.15.7
-	k8s.io/client-go v0.15.7
 )
 
 go 1.13


### PR DESCRIPTION

Some HTTP/2 implementations are vulnerable to a reset flood, potentially leading to a denial of service. Servers that accept direct connections from untrusted clients could be remotely made to allocate an unlimited amount of memory, until the program crashes. The attacker opens a number of streams and sends an invalid request over each stream that should solicit a stream of RST_STREAM frames from the peer. Depending on how the peer queues the RST_STREAM frames, this can consume excess memory, CPU, or both.